### PR TITLE
Fix post navigation problem

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -40,7 +40,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-disqus`,
       options: {
-        shortname: `passwd10`,
+        shortname: `Your Disqus-short-name here`, // Modify this to your disqus-short-name
       },
     },
     {

--- a/gatsby-meta-config.js
+++ b/gatsby-meta-config.js
@@ -19,7 +19,8 @@ module.exports = {
   planTitle: `Future Action Plan`, // Your blog planTitle
   showPlan: true, //If you don't want to see the plan, change the status to false.
   comment: {
-    disqusShortName: "passwd10", // Your disqus-short-name. check disqus.com.
+    disqusShortName: "Your Disqus-short-name here", // Your disqus-short-name. check disqus.com.
+    // You shoud modify disqus-short-name in "gatsby-config.js" too. check it.
   },
   ga: "UA-149433358-1", // Add your google analytics tranking ID
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8101,6 +8101,36 @@
         "cross-env": "^5.2.0"
       }
     },
+    "gatsby-plugin-feed": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-feed/-/gatsby-plugin-feed-2.5.3.tgz",
+      "integrity": "sha512-2Lr6eIabdatrPDQv6nCG6da+yMyU8jO9ZQcarjzUXt3DVrOoRVVj60rcj9U6j2J5acjuSL0aw1nIp+Tp6jxsDA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.6",
+        "@hapi/joi": "^15.1.1",
+        "fs-extra": "^8.1.0",
+        "lodash.merge": "^4.6.2",
+        "rss": "^1.2.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
+        }
+      }
+    },
     "gatsby-plugin-google-analytics": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.1.35.tgz",
@@ -11057,6 +11087,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "lodash.mergewith": {
       "version": "4.6.2",
@@ -15057,6 +15093,33 @@
         "inherits": "^2.0.1"
       }
     },
+    "rss": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=",
+      "dev": true,
+      "requires": {
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.25.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+          "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I=",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+          "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
+          "dev": true,
+          "requires": {
+            "mime-db": "~1.25.0"
+          }
+        }
+      }
+    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -18749,6 +18812,12 @@
           "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
         }
       }
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
     },
     "xml-parse-from-string": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "devDependencies": {
     "eslint": "^5.14.1",
     "eslint-plugin-react": "^7.11.1",
+    "gatsby-plugin-feed": "^2.5.3",
     "prettier": "^1.19.1"
   },
   "repository": {


### PR DESCRIPTION
포스트 하단에 있는 "이전 게시글"과 "다음 게시글"로 가는 네비게이션이
정상적으로 다음 게시글을 가리키지 않는 문제가 있어서 고쳤습니다.
기존에 코드상으로는 태그의 분류 없이 그냥 ALL에서 [index-1] 혹은 [index+1]로,
이전 혹은 다음 게시글로 이동되게 구현된 것 같은데, 포스트 자체가 날짜순으로 정렬되어 있지 않아서인지
엉뚱한 게시글로 이동하는 문제가 있었습니다. 그래서 태그에 따라
파일이름을 기준으로 네비게이션이 구성되도록 코드를 고쳤습니다. 예를들어
기존에는 "2020-06-02 TIL" 게시글의 네비게이션이
"<Pre: 재귀함수의 모든 것" "그림으로 배우는 네트워크 3장 정리 : Next>"
와 같이 엉뚱한 것을 가리켰다면, (심지어 저건 날짜 순서도 아니었습니다.
어떤 방식으로 포스트가 정렬되는 지 모르겠더라구요)
이제는, "2020-06-02 TIL" 게시글의 네비게이션이
"<Pre: 2020-06-01 TIL" "2020-06-03 TIL: Next>"
이렇게, 태그에 알맞게 나옵니다.
제 코드가 아니다보니 날짜를 찾아서 정렬하고 싶었으나, 네비게이션에
해당하는 게시글을 보여주는 코드흐름에서  posts.node.frontmatter 안에 date라는 프로퍼티가 없어서 사용할 수 없었습니다. 그래서 파일 이름을 기준으로 정렬하였습니다.
파일 이름에 날짜가 붙어있다면 날짜순으로 정렬될 것이고, 만약 파일이름이
중구난방이라면 그냥 문자열 sort()한 모양으로 정렬될 것입니다.